### PR TITLE
Fix cancelation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ favicon.ico
 /skin/frontend/rwd/
 /skin/install/
 /var/
+.idea

--- a/app/locale/fr_FR/Quadra_Atos.csv
+++ b/app/locale/fr_FR/Quadra_Atos.csv
@@ -10,6 +10,7 @@
 "Authorized IPs addresses","Adresses IP autorisées"
 "Automatic cancel","Annulation automatique"
 "Automatic response received but no data received for order #%s.","Réponse automatique reçue mais aucune donnée reçue pour la commande n°%s."
+"The order was already cancelled.","La commande avait déja été annulée"
 "Bank response: %s","Réponse de la Banque : %s"
 "Canceled by user","Annulation de l'internaute"
 "Capture mode: %s","Mode de capture : %s"


### PR DESCRIPTION
Lors de saisie de coordonnées de paiement erronées, l'annulation par l'IPN puis l'appel de la page cancel provoque l'annulation de la commande 2 fois de suite et le re-stockage des produits en double...
Inspiré par les autres extensions (Paypal etc).
* Vérifier $order->canCancel()
* Faire une annulation avec message en une seule ligne $order->registerCancellation($message)->save();
Validé sur 1.9. Pas de vérification de rétro-compatibilité.